### PR TITLE
using `system` in package.json for steal 0.16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "testee": "testee test.html --browsers firefox",
     "version": "git commit -am \"Update version number\" && git checkout -b release && git add -f dist/"
   },
-  "steal": {
+  "system": {
     "main": "can-event-radiochange",
     "configDependencies": [
       "live-reload"


### PR DESCRIPTION
closes https://github.com/canjs/can-event-radiochange/issues/1.